### PR TITLE
Update WordResultConditionEnglishWordMatch.java

### DIFF
--- a/src/main/java/com/github/houbb/sensitive/word/support/resultcondition/WordResultConditionEnglishWordMatch.java
+++ b/src/main/java/com/github/houbb/sensitive/word/support/resultcondition/WordResultConditionEnglishWordMatch.java
@@ -19,14 +19,6 @@ public class WordResultConditionEnglishWordMatch extends AbstractWordResultCondi
     protected boolean doMatch(IWordResult wordResult, String text, WordValidModeEnum modeEnum, IWordContext context) {
         final int startIndex = wordResult.startIndex();
         final int endIndex = wordResult.endIndex();
-        // 判断当前是否为英文单词
-        for(int i = startIndex; i < endIndex; i++) {
-            char c = text.charAt(i);
-            if(!CharUtil.isEnglish(c)) {
-                return true;
-            }
-        }
-
         // 判断处理，判断前一个字符是否为英文。如果是，则不满足
         if(startIndex > 0) {
             char preC = text.charAt(startIndex-1);
@@ -37,11 +29,20 @@ public class WordResultConditionEnglishWordMatch extends AbstractWordResultCondi
 
         // 判断后一个字符是否为英文
         if(endIndex < text.length() - 1) {
-            char afterC = text.charAt(endIndex+1);
+            char afterC = text.charAt(endIndex);
             if(CharUtil.isEnglish(afterC)) {
                 return false;
             }
         }
+        // 判断当前是否为英文单词
+        for(int i = startIndex; i < endIndex; i++) {
+            char c = text.charAt(i);
+            if(!CharUtil.isEnglish(c)) {
+                return true;
+            }
+        }
+
+        
 
         return true;
     }


### PR DESCRIPTION
要先判断当前字符前后的字符是否为英文后再判断当前字符是否为英文不然会出现以下bug International Congress会命中关键字national Congress这个判断就属于误判了。另外就是判断后一个字符是否为英文时 直接取endindex的字符就是后一个字符了，再+1就取错位置了