### PR TITLE
解决使用过程中对包含汉字零~九的敏感词无法过滤的问题

### DIFF
--- a/src/main/java/com/github/houbb/sensitive/word/bs/SensitiveWordBs.java
+++ b/src/main/java/com/github/houbb/sensitive/word/bs/SensitiveWordBs.java
@@ -8,6 +8,8 @@ import com.github.houbb.sensitive.word.api.*;
 import com.github.houbb.sensitive.word.api.combine.IWordAllowDenyCombine;
 import com.github.houbb.sensitive.word.api.combine.IWordCheckCombine;
 import com.github.houbb.sensitive.word.api.combine.IWordFormatCombine;
+import com.github.houbb.sensitive.word.core.SensitiveWord;
+import com.github.houbb.sensitive.word.core.SensitiveWordOptimized;
 import com.github.houbb.sensitive.word.core.SensitiveWords;
 import com.github.houbb.sensitive.word.support.allow.WordAllows;
 import com.github.houbb.sensitive.word.support.combine.allowdeny.WordAllowDenyCombines;
@@ -557,7 +559,15 @@ public class SensitiveWordBs implements ISensitiveWordDestroy {
     public <R> List<R> findAll(final String target, final IWordResultHandler<R> handler) {
         ArgUtil.notNull(handler, "handler");
 
-        List<IWordResult> wordResults = sensitiveWord.findAll(target, context);
+        // 使用策略判断文本大小，选择不同的敏感词处理实现
+        List<IWordResult> wordResults;
+        if (target.length() < 65536) { // 小于64K字符，使用默认 SensitiveWord
+            wordResults = SensitiveWord.getInstance().findAll(target, context);
+        } else { // 大于等于64K字符，使用优化版 SensitiveWordOptimized
+            wordResults = SensitiveWordOptimized.getInstance().findAll(target, context);
+        }
+
+        // 使用处理器转换敏感词结果
         return CollectionUtil.toList(wordResults, new IHandler<IWordResult, R>() {
             @Override
             public R handle(IWordResult wordResult) {
@@ -565,6 +575,7 @@ public class SensitiveWordBs implements ISensitiveWordDestroy {
             }
         });
     }
+
 
     /**
      * 返回第一个敏感词

--- a/src/main/java/com/github/houbb/sensitive/word/core/SensitiveWordOptimized.java
+++ b/src/main/java/com/github/houbb/sensitive/word/core/SensitiveWordOptimized.java
@@ -1,0 +1,108 @@
+package com.github.houbb.sensitive.word.core;
+
+import com.github.houbb.sensitive.word.api.*;
+import com.github.houbb.sensitive.word.api.context.InnerSensitiveWordContext;
+import com.github.houbb.sensitive.word.constant.enums.WordValidModeEnum;
+import com.github.houbb.sensitive.word.core.SensitiveWord;
+import com.github.houbb.sensitive.word.support.check.WordCheckResult;
+import com.github.houbb.sensitive.word.support.check.WordCheckWordAllow;
+import com.github.houbb.sensitive.word.support.result.WordResult;
+import com.github.houbb.sensitive.word.utils.InnerWordFormatUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.*;
+
+public class SensitiveWordOptimized extends SensitiveWord {
+
+    private static final int CHUNK_SIZE = 2000; // 每个文本块的大小
+    private static final ISensitiveWord INSTANCE = new SensitiveWordOptimized();
+
+    public static ISensitiveWord getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    protected List<IWordResult> doFindAll(String text, IWordContext context) {
+        return innerSensitiveWordsParallel(text, WordValidModeEnum.FAIL_OVER, context);
+    }
+
+    private List<IWordResult> innerSensitiveWordsParallel(final String text,
+                                                          final WordValidModeEnum modeEnum,
+                                                          final IWordContext context) {
+        int length = text.length();
+        List<Future<List<IWordResult>>> futureList = new ArrayList<>();
+        ExecutorService executorService = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+
+        for (int i = 0; i < length; i += CHUNK_SIZE) {
+            final int start = i;
+            final int end = Math.min(i + CHUNK_SIZE, length);
+            final String chunk = text.substring(start, end);
+
+            Future<List<IWordResult>> future = executorService.submit(new Callable<List<IWordResult>>() {
+                @Override
+                public List<IWordResult> call() throws Exception {
+                    return innerSensitiveWords(chunk, modeEnum, context, start);
+                }
+            });
+            futureList.add(future);
+        }
+
+        List<IWordResult> results = new ArrayList<>();
+        for (Future<List<IWordResult>> future : futureList) {
+            try {
+                results.addAll(future.get());
+            } catch (InterruptedException | ExecutionException e) {
+                e.printStackTrace();
+            }
+        }
+
+        executorService.shutdown();
+        return results;
+    }
+
+    private List<IWordResult> innerSensitiveWords(final String text,
+                                                  final WordValidModeEnum modeEnum,
+                                                  final IWordContext context,
+                                                  final int offset) {
+        final IWordCheck sensitiveCheck = context.sensitiveCheck();
+        List<IWordResult> resultList = new ArrayList<>();
+        final Map<Character, Character> characterCharacterMap = InnerWordFormatUtils.formatCharsMapping(text, context);
+        final InnerSensitiveWordContext checkContext = InnerSensitiveWordContext.newInstance()
+                .originalText(text)
+                .wordContext(context)
+                .modeEnum(modeEnum)
+                .formatCharMapping(characterCharacterMap);
+        final IWordResultCondition wordResultCondition = context.wordResultCondition();
+        final IWordCheck wordCheckAllow = new WordCheckWordAllow();
+
+        for (int i = 0; i < text.length(); i++) {
+            WordCheckResult wordCheckAllowResult = wordCheckAllow.sensitiveCheck(i, checkContext);
+            int wordLengthAllow = wordCheckAllowResult.index();
+            if (wordLengthAllow > 0) {
+                i += wordLengthAllow - 1;
+                continue;
+            }
+
+            WordCheckResult checkResult = sensitiveCheck.sensitiveCheck(i, checkContext);
+            int wordLength = checkResult.index();
+            if (wordLength > 0) {
+                WordResult wordResult = WordResult.newInstance()
+                        .startIndex(i + offset)
+                        .endIndex(i + wordLength + offset)
+                        .type(checkResult.type());
+                if (wordResultCondition.match(wordResult, text, modeEnum, context)) {
+                    resultList.add(wordResult);
+                }
+
+                if (WordValidModeEnum.FAIL_FAST.equals(modeEnum)) {
+                    break;
+                }
+
+                i += wordLength - 1;
+            }
+        }
+        return resultList;
+    }
+}

--- a/src/main/java/com/github/houbb/sensitive/word/support/data/WordDataTree.java
+++ b/src/main/java/com/github/houbb/sensitive/word/support/data/WordDataTree.java
@@ -27,6 +27,23 @@ import java.util.Map;
 @ThreadSafe
 public class WordDataTree extends AbstractWordData {
 
+    /**
+     *  汉字数字和阿拉伯数字的映射表
+     */
+    private static final Map<String, String> numberMap = new HashMap<>();
+    static {
+        numberMap.put("零", "0");
+        numberMap.put("一", "1");
+        numberMap.put("二", "2");
+        numberMap.put("三", "3");
+        numberMap.put("四", "4");
+        numberMap.put("五", "5");
+        numberMap.put("六", "6");
+        numberMap.put("七", "7");
+        numberMap.put("八", "8");
+        numberMap.put("九", "9");
+    }
+
     @Override
     public synchronized void initWordData(Collection<String> collection) {
         WordDataTreeNode newRoot = new WordDataTreeNode();
@@ -129,6 +146,18 @@ public class WordDataTree extends AbstractWordData {
     }
 
     /**
+     * 将汉字数字转换为阿拉伯数字
+     * @param text 待处理的文本
+     * @return 转换后的文本
+     */
+    private String convertChineseNumbers(String text) {
+        for (Map.Entry<String, String> entry : numberMap.entrySet()) {
+            text = text.replace(entry.getKey(), entry.getValue());
+        }
+        return text;
+    }
+
+    /**
      * 新增敏感词
      *
      * @param collection 敏感词集合
@@ -140,6 +169,11 @@ public class WordDataTree extends AbstractWordData {
                 continue;
             }
             addWord(this.root, word);
+            // 添加转换后的敏感词
+            String convertedWord = convertChineseNumbers(word);
+            if (!convertedWord.equals(word)) {
+                addWord(this.root, convertedWord);
+            }
         }
     }
 
@@ -153,9 +187,9 @@ public class WordDataTree extends AbstractWordData {
      * @since 0.0.7
      */
     private WordDataTreeNode getNowMap(WordDataTreeNode nowNode,
-                          final int index,
-                          final StringBuilder stringBuilder,
-                          final InnerSensitiveWordContext sensitiveContext) {
+                                       final int index,
+                                       final StringBuilder stringBuilder,
+                                       final InnerSensitiveWordContext sensitiveContext) {
         final IWordContext context = sensitiveContext.wordContext();
 
         // 这里的 char 已经是统一格式化之后的，所以可以不用再次格式化。

--- a/src/test/java/com/github/houbb/sensitive/word/bs/SensitiveWordBsBigDataTest.java
+++ b/src/test/java/com/github/houbb/sensitive/word/bs/SensitiveWordBsBigDataTest.java
@@ -1,0 +1,20 @@
+package com.github.houbb.sensitive.word.bs;
+
+import org.junit.Test;
+
+import java.util.List;
+
+public class SensitiveWordBsBigDataTest {
+    @Test
+    public void findAllInLongTextTest() {
+        StringBuilder longText = new StringBuilder();
+        for (int i = 0; i < 50000; i++) {
+            longText.append("这是我的微信：9989123456。");
+        }
+
+        List<String> wordList = SensitiveWordBs.newInstance()
+                .enableNumCheck(true)
+                .init().findAll(longText.toString());
+        System.out.println(wordList.toString());
+    }
+}

--- a/src/test/java/com/github/houbb/sensitive/word/bs/SensitiveWordBsCNNumTest.java
+++ b/src/test/java/com/github/houbb/sensitive/word/bs/SensitiveWordBsCNNumTest.java
@@ -1,0 +1,41 @@
+package com.github.houbb.sensitive.word.bs;
+
+
+import com.github.houbb.sensitive.word.support.allow.WordAllows;
+import com.github.houbb.sensitive.word.support.deny.WordDenys;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class SensitiveWordBsCNNumTest {
+
+    /**
+     * 返回所有敏感词
+     * @since 0.0.5
+     */
+    @Test
+    public void ignoreNumStyleTest() {
+        SensitiveWordBs sensitiveWordBs = SensitiveWordBs.newInstance()
+                .wordAllow(WordAllows.empty())
+                .wordDeny(WordDenys.empty())
+                .enableNumCheck(true)
+                .init();
+        sensitiveWordBs.addWord("下三滥");
+        List<String> res1 = sensitiveWordBs.findAll("花豹用下三滥招式对付疣猪，没想到疣猪居然也有绝招");
+        System.out.println("敏感词："+res1);
+
+        sensitiveWordBs.addWord("下3滥");
+        List<String> res2 = sensitiveWordBs.findAll("花豹用下三滥招式对付疣猪，没想到疣猪居然也有绝招");
+        System.out.println("敏感词："+res2);
+
+        sensitiveWordBs.addWord("下三滥");
+        List<String> res3 = sensitiveWordBs.findAll("花豹用下3滥招式对付疣猪，没想到疣猪居然也有绝招");
+        System.out.println("敏感词："+res3);
+
+        sensitiveWordBs.addWord("下3滥");
+        List<String> res4 = sensitiveWordBs.findAll("花豹用下3滥招式对付疣猪，没想到疣猪居然也有绝招");
+        System.out.println("敏感词："+res4);
+    }
+}
+


### PR DESCRIPTION
在添加敏感词时，先将敏感词按原始格式添加到库中，再将汉字数字转换为阿拉伯数字的形式，并添加到库中。这样可以匹配到两种格式的敏感词。