### PR TITLE
解决超长文本过滤器持续挤占CPU资源问题

### DIFF
--- a/src/main/java/com/github/houbb/sensitive/word/bs/SensitiveWordBs.java
+++ b/src/main/java/com/github/houbb/sensitive/word/bs/SensitiveWordBs.java
@@ -8,6 +8,8 @@ import com.github.houbb.sensitive.word.api.*;
 import com.github.houbb.sensitive.word.api.combine.IWordAllowDenyCombine;
 import com.github.houbb.sensitive.word.api.combine.IWordCheckCombine;
 import com.github.houbb.sensitive.word.api.combine.IWordFormatCombine;
+import com.github.houbb.sensitive.word.core.SensitiveWord;
+import com.github.houbb.sensitive.word.core.SensitiveWordOptimized;
 import com.github.houbb.sensitive.word.core.SensitiveWords;
 import com.github.houbb.sensitive.word.support.allow.WordAllows;
 import com.github.houbb.sensitive.word.support.combine.allowdeny.WordAllowDenyCombines;
@@ -556,8 +558,15 @@ public class SensitiveWordBs implements ISensitiveWordDestroy {
      */
     public <R> List<R> findAll(final String target, final IWordResultHandler<R> handler) {
         ArgUtil.notNull(handler, "handler");
+        // 使用策略判断文本大小，选择不同的敏感词处理实现
+        List<IWordResult> wordResults;
+        if (target.length() < 65536) { // 小于64K字符，使用默认 SensitiveWord
+            wordResults = SensitiveWord.getInstance().findAll(target, context);
+        } else { // 大于等于64K字符，使用优化版 SensitiveWordOptimized
+            wordResults = SensitiveWordOptimized.getInstance().findAll(target, context);
+        }
 
-        List<IWordResult> wordResults = sensitiveWord.findAll(target, context);
+        // 使用处理器转换敏感词结果
         return CollectionUtil.toList(wordResults, new IHandler<IWordResult, R>() {
             @Override
             public R handle(IWordResult wordResult) {

--- a/src/main/java/com/github/houbb/sensitive/word/core/SensitiveWordOptimized.java
+++ b/src/main/java/com/github/houbb/sensitive/word/core/SensitiveWordOptimized.java
@@ -1,0 +1,108 @@
+package com.github.houbb.sensitive.word.core;
+
+import com.github.houbb.sensitive.word.api.*;
+import com.github.houbb.sensitive.word.api.context.InnerSensitiveWordContext;
+import com.github.houbb.sensitive.word.constant.enums.WordValidModeEnum;
+import com.github.houbb.sensitive.word.core.SensitiveWord;
+import com.github.houbb.sensitive.word.support.check.WordCheckResult;
+import com.github.houbb.sensitive.word.support.check.WordCheckWordAllow;
+import com.github.houbb.sensitive.word.support.result.WordResult;
+import com.github.houbb.sensitive.word.utils.InnerWordFormatUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.*;
+
+public class SensitiveWordOptimized extends SensitiveWord {
+
+    private static final int CHUNK_SIZE = 2000; // 每个文本块的大小
+    private static final ISensitiveWord INSTANCE = new SensitiveWordOptimized();
+
+    public static ISensitiveWord getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    protected List<IWordResult> doFindAll(String text, IWordContext context) {
+        return innerSensitiveWordsParallel(text, WordValidModeEnum.FAIL_OVER, context);
+    }
+
+    private List<IWordResult> innerSensitiveWordsParallel(final String text,
+                                                          final WordValidModeEnum modeEnum,
+                                                          final IWordContext context) {
+        int length = text.length();
+        List<Future<List<IWordResult>>> futureList = new ArrayList<>();
+        ExecutorService executorService = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+
+        for (int i = 0; i < length; i += CHUNK_SIZE) {
+            final int start = i;
+            final int end = Math.min(i + CHUNK_SIZE, length);
+            final String chunk = text.substring(start, end);
+
+            Future<List<IWordResult>> future = executorService.submit(new Callable<List<IWordResult>>() {
+                @Override
+                public List<IWordResult> call() throws Exception {
+                    return innerSensitiveWords(chunk, modeEnum, context, start);
+                }
+            });
+            futureList.add(future);
+        }
+
+        List<IWordResult> results = new ArrayList<>();
+        for (Future<List<IWordResult>> future : futureList) {
+            try {
+                results.addAll(future.get());
+            } catch (InterruptedException | ExecutionException e) {
+                e.printStackTrace();
+            }
+        }
+
+        executorService.shutdown();
+        return results;
+    }
+
+    private List<IWordResult> innerSensitiveWords(final String text,
+                                                  final WordValidModeEnum modeEnum,
+                                                  final IWordContext context,
+                                                  final int offset) {
+        final IWordCheck sensitiveCheck = context.sensitiveCheck();
+        List<IWordResult> resultList = new ArrayList<>();
+        final Map<Character, Character> characterCharacterMap = InnerWordFormatUtils.formatCharsMapping(text, context);
+        final InnerSensitiveWordContext checkContext = InnerSensitiveWordContext.newInstance()
+                .originalText(text)
+                .wordContext(context)
+                .modeEnum(modeEnum)
+                .formatCharMapping(characterCharacterMap);
+        final IWordResultCondition wordResultCondition = context.wordResultCondition();
+        final IWordCheck wordCheckAllow = new WordCheckWordAllow();
+
+        for (int i = 0; i < text.length(); i++) {
+            WordCheckResult wordCheckAllowResult = wordCheckAllow.sensitiveCheck(i, checkContext);
+            int wordLengthAllow = wordCheckAllowResult.index();
+            if (wordLengthAllow > 0) {
+                i += wordLengthAllow - 1;
+                continue;
+            }
+
+            WordCheckResult checkResult = sensitiveCheck.sensitiveCheck(i, checkContext);
+            int wordLength = checkResult.index();
+            if (wordLength > 0) {
+                WordResult wordResult = WordResult.newInstance()
+                        .startIndex(i + offset)
+                        .endIndex(i + wordLength + offset)
+                        .type(checkResult.type());
+                if (wordResultCondition.match(wordResult, text, modeEnum, context)) {
+                    resultList.add(wordResult);
+                }
+
+                if (WordValidModeEnum.FAIL_FAST.equals(modeEnum)) {
+                    break;
+                }
+
+                i += wordLength - 1;
+            }
+        }
+        return resultList;
+    }
+}

--- a/src/test/java/com/github/houbb/sensitive/word/bs/SensitiveWordBsBigDataTest.java
+++ b/src/test/java/com/github/houbb/sensitive/word/bs/SensitiveWordBsBigDataTest.java
@@ -1,0 +1,20 @@
+package com.github.houbb.sensitive.word.bs;
+
+import org.junit.Test;
+
+import java.util.List;
+
+public class SensitiveWordBsBigDataTest {
+    @Test
+    public void findAllInLongTextTest() {
+        StringBuilder longText = new StringBuilder();
+        for (int i = 0; i < 50000; i++) {
+            longText.append("这是我的微信：9989123456。");
+        }
+
+        List<String> wordList = SensitiveWordBs.newInstance()
+                .enableNumCheck(true)
+                .init().findAll(longText.toString());
+        System.out.println(wordList.toString());
+    }
+}


### PR DESCRIPTION
感谢作者的回答，您说的是正确的，我的确是将超长文本按固定大小分块，并利用多线程并行处理每个分块最后处理完进行合并的方法去解决这个问题，确实可以大幅提高敏感词过滤的效率原来的处理时间如下图1
![image](https://github.com/user-attachments/assets/60c2c6c2-974b-4a35-a0c3-e6991051471d)
优化后的处理时间如下图2
![image](https://github.com/user-attachments/assets/958dd102-26f2-4e7b-a272-0ba7dcde425c)
但是忽略了避免提前将多线程等复杂度引入到核心基础组件这个问题，这意味着在项目的初期阶段，应该避免使用复杂的多线程技术，以保持核心组件的简洁和稳定性。后续我会再思考一下这个问题，再次感谢